### PR TITLE
Fix display date - Video Uploads and Media Pages

### DIFF
--- a/src/be/.vscode/settings.json
+++ b/src/be/.vscode/settings.json
@@ -5,9 +5,9 @@
   "python.testing.pytestArgs": ["."],
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
-  "python-envs.defaultPackageManager": "ms-python.python:poetry",
+  "python-envs.defaultPackageManager": "ms-python.python:pip",
   "python.terminal.useEnvFile": true,
   "python.terminal.activateEnvironment": true,
   "python.terminal.activateEnvInCurrentTerminal": true,
-  "python-envs.defaultEnvManager": "ms-python.python:poetry"
+  "python-envs.defaultEnvManager": "ms-python.python:venv"
 }

--- a/src/be/app/main.py
+++ b/src/be/app/main.py
@@ -16,7 +16,7 @@ print(
     "********--------App Settings loaded: "
     + str((settings.BACKEND_CORS_ORIGINS is not None and settings.BACKEND_CORS_ORIGINS != ""))
 )
-print("***** Route Path: " + settings.API_V1_STR)
+print("***** Route Path: " + "/" + settings.API_V1_STR)
 
 origins = [
     "http://localhost.tiangolo.com",
@@ -41,7 +41,7 @@ app = FastAPI(
     title=settings.PROJECT_NAME,
     description=settings.PROJECT_DESCRIPTION,
     version=settings.VERSION,
-    openapi_url=f"{settings.API_V1_STR}/openapi.json",
+    openapi_url=f"/{settings.API_V1_STR}/openapi.json",
     # generate_unique_id_function=custom_generate_unique_id,
 )
 
@@ -61,7 +61,7 @@ try:
     }
     app.security = [{"OAuth2PasswordBearer": [s.value for s in Scope]}]
 
-    app.include_router(api_router, prefix=settings.API_V1_STR)
+    app.include_router(api_router, prefix= "/" +settings.API_V1_STR)
 
     templates = Jinja2Templates(directory=Path(__file__).parent / "templates")
 

--- a/src/fe/app/(main)/media/page.tsx
+++ b/src/fe/app/(main)/media/page.tsx
@@ -142,7 +142,7 @@ export default function Media() {
                           {v.speaker_name || "Unknown"}
                         </h1>
                         <h1 className="text-black/40 font-normal">
-                          {new Date(v.created_on).toLocaleDateString("en-US")}
+                          {new Date(v.media_association_date).toLocaleDateString("en-US")}
                         </h1>
                       </div>
                     </div>

--- a/src/fe/app/(main)/video-uploads/page.tsx
+++ b/src/fe/app/(main)/video-uploads/page.tsx
@@ -135,7 +135,7 @@ export default function VideoUploadsPage() {
                           <h1 className="text-xl">{v.upload_name || "Untitled"}</h1>
                           <h1 className="text-black/40 font-normal">{v.speaker_name || "Unknown"}</h1>
                           <h1 className="text-black/40 font-normal">
-                            {new Date(v.created_on).toLocaleDateString("en-US")}
+                            {new Date(v.media_association_date).toLocaleDateString("en-US")}
                           </h1>
                         </div>
                       </div>


### PR DESCRIPTION
The display date on the Video Uploads and Media pages were the date that the video was uploaded. This got changed to display the date that the service happened. 
This partially addresses #111, we have not added a drop down for the type of service. 